### PR TITLE
Use production site URL when building from master branch

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -51,10 +51,10 @@ gulp.task("template", () => {
   };
 
   if (serve) {
-    // Use localhost when developing.
+    // Use localhost when serving locally.
     data.meta.url = "http://localhost:3000";
-  } else if (process.env.DEPLOY_URL) {
-    // Use the Netlify deploy URL when doing a CI build.
+  } else if (process.env.BRANCH !== "master" && process.env.DEPLOY_URL) {
+    // Use the unique deploy URL when doing a development CI build.
     data.meta.url = process.env.DEPLOY_URL;
   }
 


### PR DESCRIPTION
When developing we use the site URL that's unique to each deploy. But this was done on all deploys including from master branch. This means the production URL (cyberqueer.netlify.com) does not work because all the code expects it to be at a different domain.